### PR TITLE
service injection test

### DIFF
--- a/tests/unit/components/sparkles-component-test.js
+++ b/tests/unit/components/sparkles-component-test.js
@@ -1,0 +1,15 @@
+import { inject as service } from "@ember/service";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import SparklesComponent from "sparkles-component";
+
+module('Unit | Component | sparkles component', function (hooks) {
+  setupTest(hooks);
+  test('injecting service', async function (assert) {
+    const RoutingComponent = class extends SparklesComponent {
+      router = service();
+    }
+    const comp = new RoutingComponent();
+    assert.ok(comp.router.currentRouteName);
+  });
+});


### PR DESCRIPTION
Test case for failing service injection. I don't know if I constructed the test correctly at all. Though what I originally was trying was this:

```
ember install ember-key-manager
```

```ts
// src/services/key-manager.ts
import Service from 'ember-key-manager/services/key-manager';

export default class KeyManagerService extends Service {
    // my modifications (don't matter to this case)
}
```

```ts
import Component from 'sparkles-component';
import { service } from '@ember-decorators/service';
import KeyManagerService from 'my-project/services/key-manager';

export default class MyComponent extends Component {
	@service keyManager: KeyManagerService;
}
```

In my original setup I also used MU. Also the error message is different from the original one.

PR for #1 