### PR TITLE
Now ember passes the class itself to the component manager, not the factory

### DIFF
--- a/addon/component-managers/sparkles.js
+++ b/addon/component-managers/sparkles.js
@@ -13,10 +13,8 @@ export default class SparklesComponentManager {
     });
   }
 
-  createComponent(Factory, args) {
-    // TODO: fix this in Ember, we should receive the `.class` directly
-    // but instead are receiving the `FactoryManager` (the private one)
-    return new Factory.class(args.named);
+  createComponent(Klass, args) {
+    return new Klass(args.named);
   }
 
   updateComponent(component, args) {


### PR DESCRIPTION
This is fixed in Ember 3.4 now.