### PR TITLE
going decorators stage-2

### DIFF
--- a/addon/tracked.ts
+++ b/addon/tracked.ts
@@ -107,13 +107,21 @@ function installTrackedProperty(_target: object, key: string | symbol, descripto
 }
 
 
-function _tracked(target: object, key: string | symbol, descriptor?: PropertyDescriptor, dependencies?: string[]): PropertyDescriptor {
+function _tracked(target: object, key: string | symbol, descriptor?: PropertyDescriptor, dependencies?: string[]): any {
+  let desc: PropertyDescriptor;
   // descriptor is undefined for typescript class fields
   if (descriptor === undefined || 'initializer' in descriptor) {
-    return installTrackedProperty(target, key, descriptor);
+    desc = installTrackedProperty(target, key, descriptor);
   } else {
-    return descriptorForTrackedComputedProperty(target, key, descriptor, dependencies);
+    desc = descriptorForTrackedComputedProperty(target, key, descriptor, dependencies);
   }
+
+  return {
+    kind: 'method',
+    placement: 'prototype',
+    key,
+    descriptor: desc
+  };
 }
 
 // type CompatiblePropertyDecorator = (target: object, key: string | symbol, descriptor: PropertyDescriptor) => PropertyDescriptor;


### PR DESCRIPTION
I did update those `@tracked` decorators to stage-2, because my app with `ember-decorators@^3.1.0` was complaining about those old ones.
Of couse I broke the test-suite here. I need some assistance here, how to properly deal with stage-1 and stage-2 decorators at the same time. @pzuraq can you help? So I can turn these tests green?