### PR TITLE
Component manager deprecation

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -13,7 +13,7 @@ class SparklesComponent<T = object> {
   destroy() {}
 }
 
-if (gte('3.8.0')) {
+if (gte('3.8.0-beta.1')) {
   setComponentManager((owner: ApplicationInstance) => {
     return new SparklesComponentManager(owner)
   }, SparklesComponent);

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -12,9 +12,13 @@ class SparklesComponent<T = object> {
   destroy() {}
 }
 
-setComponentManager((owner: ApplicationInstance) => {
-  return new SparklesComponentManager(owner)
-}, SparklesComponent);
+// if (ember >= '3.8.0') {
+//   setComponentManager((owner: ApplicationInstance) => {
+//     return new SparklesComponentManager(owner)
+//   }, SparklesComponent);
+// } else {
+  setComponentManager('sparkles', SparklesComponent);
+// }
 
 export default SparklesComponent;
 

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,5 +1,6 @@
 import ApplicationInstance from '@ember/application/instance';
 import { setComponentManager } from '@ember/component';
+import { gte } from 'ember-compatibility-helpers';
 import SparklesComponentManager from './component-managers/sparkles';
 
 class SparklesComponent<T = object> {
@@ -12,13 +13,13 @@ class SparklesComponent<T = object> {
   destroy() {}
 }
 
-// if (ember >= '3.8.0') {
-//   setComponentManager((owner: ApplicationInstance) => {
-//     return new SparklesComponentManager(owner)
-//   }, SparklesComponent);
-// } else {
+if (gte('3.8.0')) {
+  setComponentManager((owner: ApplicationInstance) => {
+    return new SparklesComponentManager(owner)
+  }, SparklesComponent);
+} else {
   setComponentManager('sparkles', SparklesComponent);
-// }
+}
 
 export default SparklesComponent;
 

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,4 +1,6 @@
+import ApplicationInstance from '@ember/application/instance';
 import { setComponentManager } from '@ember/component';
+import SparklesComponentManager from './component-managers/sparkles';
 
 class SparklesComponent<T = object> {
   constructor(public args: T) {}
@@ -9,8 +11,12 @@ class SparklesComponent<T = object> {
   // didRender() {}
   destroy() {}
 }
-setComponentManager('sparkles', SparklesComponent);
+
+setComponentManager((owner: ApplicationInstance) => {
+  return new SparklesComponentManager(owner)
+}, SparklesComponent);
 
 export default SparklesComponent;
 
 export { tracked } from './tracked';
+

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "ember-cli-is-package-missing": "^1.0.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-path-utils": "^1.0.0",
-    "ember-cli-string-utils": "^1.1.0"
+    "ember-cli-string-utils": "^1.1.0",
+    "ember-compatibility-helpers": "^1.1.2"
   },
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1376,6 +1376,13 @@ babel-plugin-debug-macros@^0.1.10:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz#0120ac20ce06ccc57bf493b667cf24b85c28da7a"
+  integrity sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-debug-macros@^0.2.0-beta.6:
   version "0.2.0-beta.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0-beta.6.tgz#ecdf6e408d5c863ab21740d7ad7f43f027d2f912"
@@ -3516,7 +3523,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
+ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.1, ember-cli-version-checker@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz#305ce102390c66e4e0f1432dea9dc5c7c19fed98"
   integrity sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==
@@ -3615,6 +3622,15 @@ ember-cli@~3.4.0-beta.1:
     walk-sync "^0.3.0"
     watch-detector "^0.1.0"
     yam "^0.0.24"
+
+ember-compatibility-helpers@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.1.2.tgz#ae0ee4a7a2858b5ffdf79b428c23aee85c47d93d"
+  integrity sha512-yN163MzERpotO8M0b+q+kXs4i3Nx6aIriiZHWv+yXQzr2TAtYlVwg9V7/3+jcurOa3oDEYDpN7y9UZ6q3mnoTg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^2.1.1"
+    semver "^5.4.1"
 
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"


### PR DESCRIPTION
Since `setComponentManager` got a new signature in ember 3.8 - working with ember canary versions is complaining about "legacy" usage. My idea was to gateway this depending on the ember version (see the schematic if). What's the best way to check for ember-version here, so I can make it truly work?

PS. I tried `ember-cli-version-checker` at first but was curious to shim it in. Is there a more neat way to do it?